### PR TITLE
修复侧边栏展开时遮挡主内容区域的问题

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -141,6 +141,25 @@ function App() {
     }
   }, [isDownloadingUpdate, setUpdateInfo]);
 
+  const [sidebarWidth, setSidebarWidth] = useState(SIDEBAR_COLLAPSED_WIDTH);
+  const sidebarRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // 仅在悬浮模式下需要监听宽度
+    if (sidebarMode !== 'floating') return;
+    if (!sidebarRef.current) return;
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setSidebarWidth(entry.contentRect.width);
+      }
+    });
+
+    observer.observe(sidebarRef.current);
+
+    return () => observer.disconnect();
+  }, [sidebarMode]); // 依赖 sidebarMode，切换时重新绑定
+
   return (
     <>
       <div
@@ -184,7 +203,7 @@ function App() {
         {sidebarMode === "floating" ? (
           <>
             {/* 悬浮侧边栏 - 绝对定位，占满窗口高度 */}
-            <div
+            <div ref={sidebarRef}  // 添加 ref
               className="absolute z-50"
               style={{
                 left: `${SIDEBAR_LEFT}px`,
@@ -211,9 +230,9 @@ function App() {
 
             {/* 主内容区域 - 绝对定位，从顶部开始 */}
             <div
-              className="absolute z-40 overflow-hidden rounded-b-[12px]"
-              style={{
-                left: `${SIDEBAR_LEFT + SIDEBAR_COLLAPSED_WIDTH}px`,
+                className="absolute z-40 overflow-hidden rounded-b-[12px]"
+                style={{
+                  left: `${SIDEBAR_LEFT + sidebarWidth}px`,  // 动态计算
                 right: "0",
                 top: !isMacOS || showTitleBar ? "36px" : "0",
                 bottom: "0",


### PR DESCRIPTION
问题
侧边栏展开后，主内容区域被遮挡，无法正常显示和使用

原因
主内容区域的 CSS 没有根据侧边栏宽度动态调整 `margin-left`，导致布局重叠

解决
- 在 `App.tsx` 中监听侧边栏展开/收起状态
- 动态设置主内容区域的左边距，使其与侧边栏宽度同步
