### PR TITLE
fix: 优化用户信息获取失败时的错误处理逻辑

### DIFF
--- a/src/components/pages/Home/hooks/useUserInfo.ts
+++ b/src/components/pages/Home/hooks/useUserInfo.ts
@@ -77,13 +77,22 @@ export function useUserInfo(
           tunnel: data.tunnel,
         };
         saveStoredUser(updatedUser);
+        onUserChangeRef.current?.(updatedUser);
       } catch (err) {
-        clearStoredUser();
-        setUserInfo(null);
-        homePageCache.userInfo = null;
-        homePageCache.flowData = [];
-        homePageCache.signInInfo = null;
-        onUserChangeRef.current?.(null);
+        const message = err instanceof Error ? err.message : "";
+        const currentStoredUser = getStoredUser();
+        if (
+          !currentStoredUser ||
+          message.includes("登录信息已过期") ||
+          message.includes("invalid_grant")
+        ) {
+          clearStoredUser();
+          setUserInfo(null);
+          homePageCache.userInfo = null;
+          homePageCache.flowData = [];
+          homePageCache.signInInfo = null;
+          onUserChangeRef.current?.(null);
+        }
         console.error("获取用户信息失败", err);
       }
     };

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -570,17 +570,12 @@ export async function fetchUserInfo(token?: string): Promise<UserInfo> {
     ? toBearerHeader(accessToken)
     : toBearerHeader(legacyToken!);
 
-  try {
-    const data = await request<UserInfo>("/userinfo", {
-      headers: { authorization },
-    });
+  const data = await request<UserInfo>("/userinfo", {
+    headers: { authorization },
+  });
 
-    if (data) return data as UserInfo;
-    throw new Error("获取用户信息失败");
-  } catch (err) {
-    clearStoredUser();
-    throw err;
-  }
+  if (data) return data as UserInfo;
+  throw new Error("获取用户信息失败");
 }
 
 export async function fetchSignInInfo(token?: string): Promise<SignInInfo> {


### PR DESCRIPTION
移除fetchUserInfo中冗余的try-catch，由调用方统一处理错误
在useUserInfo中增加特定错误码判断，仅在登录过期或无效授权时才清空用户数据