### PR TITLE
feat: 添加 frpc 启动文件缺失时的引导弹窗和日志提示

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,7 +1,6 @@
 use std::{
     env, fs,
     path::{Path, PathBuf},
-    process::Command,
 };
 
 fn main() {

--- a/src/components/dialogs/AntivirusWarningDialog.tsx
+++ b/src/components/dialogs/AntivirusWarningDialog.tsx
@@ -9,18 +9,18 @@ interface AntivirusWarningDialogProps {
 }
 
 export function AntivirusWarningDialog({
-  isOpen,
-  onClose,
-  onConfirm,
-}: AntivirusWarningDialogProps) {
+                                         isOpen,
+                                         onClose,
+                                         onConfirm,
+                                       }: AntivirusWarningDialogProps) {
   const [frpcDir, setFrpcDir] = useState<string>("");
   const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
       invoke<string>("get_frpc_directory")
-        .then(setFrpcDir)
-        .catch((err) => console.error("获取frpc目录失败:", err));
+          .then(setFrpcDir)
+          .catch((err) => console.error("获取frpc目录失败:", err));
     }
   }, [isOpen]);
 
@@ -42,91 +42,90 @@ export function AntivirusWarningDialog({
   };
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm animate-in fade-in duration-200"
-      onClick={onClose}
-    >
       <div
-        className="w-full max-w-md rounded-2xl bg-card/95 backdrop-blur-md border border-border/50 p-8 shadow-2xl animate-in zoom-in-95 slide-in-from-bottom-4 duration-300"
-        onClick={(e) => e.stopPropagation()}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm animate-in fade-in duration-200"
+          onClick={onClose}
       >
-        {/* 头部 */}
-        <div className="flex items-center justify-between mb-6">
-          <div className="flex items-center gap-3">
-            <div className="h-10 w-10 rounded-xl bg-gradient-to-br from-foreground to-foreground/80 flex items-center justify-center shadow-sm">
-              <AlertTriangle className="w-5 h-5 text-background" />
-            </div>
-            <div>
-              <h2 className="text-lg font-bold text-foreground">下载被拦截</h2>
-              <p className="text-xs text-muted-foreground">
-                杀毒软件阻止了下载
-              </p>
-            </div>
-          </div>
-          <button
-            type="button"
-            className="h-8 w-8 rounded-lg text-muted-foreground hover:text-foreground hover:bg-foreground/10 transition-all duration-200 flex items-center justify-center"
-            onClick={onClose}
-          >
-            <X className="w-4 h-4" />
-          </button>
-        </div>
-
-        {/* 内容 */}
-        <div className="space-y-4">
-          <p className="text-sm text-muted-foreground leading-relaxed">
-            frpc 客户端可能被杀毒软件（如 Windows Defender）误判为可疑程序。
-          </p>
-
-          <div className="space-y-2">
-            <p className="text-sm font-medium text-foreground">
-              frpc 安装目录：
-            </p>
-            <div className="flex items-center gap-2">
-              <div className="flex-1 px-3 py-2 rounded-lg border border-border/50 bg-background/50 text-xs font-mono text-foreground break-all">
-                {frpcDir || "加载中..."}
+        <div
+            className="w-full max-w-md rounded-2xl bg-card/95 backdrop-blur-md border border-border/50 p-8 shadow-2xl animate-in zoom-in-95 slide-in-from-bottom-4 duration-300"
+            onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-center justify-between mb-6">
+            <div className="flex items-center gap-3">
+              <div className="h-10 w-10 rounded-xl bg-gradient-to-br from-foreground to-foreground/80 flex items-center justify-center shadow-sm">
+                <AlertTriangle className="w-5 h-5 text-background" />
               </div>
-              <button
-                onClick={handleCopy}
-                disabled={!frpcDir}
-                className="flex-shrink-0 h-8 w-8 rounded-lg border border-border/50 bg-background/50 flex items-center justify-center hover:bg-foreground/5 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
-                title="复制路径"
-              >
-                {copied ? (
-                  <Check className="w-4 h-4 text-green-500" />
-                ) : (
-                  <Copy className="w-3.5 h-3.5 text-muted-foreground" />
-                )}
-              </button>
+              <div>
+                <h2 className="text-lg font-bold text-foreground">启动被阻止</h2>
+                <p className="text-xs text-muted-foreground">
+                  杀毒软件可能已删除 frpc 文件
+                </p>
+              </div>
+            </div>
+            <button
+                type="button"
+                className="h-8 w-8 rounded-lg text-muted-foreground hover:text-foreground hover:bg-foreground/10 transition-all duration-200 flex items-center justify-center"
+                onClick={onClose}
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              frpc 客户端可能已被杀毒软件（如 Windows Defender）误判为可疑程序并被删除。
+              请将其安装目录添加到白名单，然后重新尝试启动隧道。
+            </p>
+
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-foreground">
+                frpc 安装目录：
+              </p>
+              <div className="flex items-center gap-2">
+                <div className="flex-1 px-3 py-2 rounded-lg border border-border/50 bg-background/50 text-xs font-mono text-foreground break-all">
+                  {frpcDir || "加载中..."}
+                </div>
+                <button
+                    onClick={handleCopy}
+                    disabled={!frpcDir}
+                    className="flex-shrink-0 h-8 w-8 rounded-lg border border-border/50 bg-background/50 flex items-center justify-center hover:bg-foreground/5 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+                    title="复制路径"
+                >
+                  {copied ? (
+                      <Check className="w-4 h-4 text-green-500" />
+                  ) : (
+                      <Copy className="w-3.5 h-3.5 text-muted-foreground" />
+                  )}
+                </button>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-foreground">解决方法：</p>
+              <ol className="space-y-2 text-sm text-muted-foreground pl-5 list-decimal">
+                <li>打开杀毒软件设置</li>
+                <li>将上述目录添加到白名单（排除项）</li>
+                <li>进入软件设置重新下载frpc</li>
+                <li>重新尝试启动隧道</li>
+              </ol>
             </div>
           </div>
 
-          <div className="space-y-2">
-            <p className="text-sm font-medium text-foreground">解决方法：</p>
-            <ol className="space-y-2 text-sm text-muted-foreground pl-5 list-decimal">
-              <li>打开杀毒软件设置</li>
-              <li>将上面的目录添加到白名单</li>
-              <li>重新下载 frpc 客户端</li>
-            </ol>
+          <div className="flex gap-3 mt-6">
+            <button
+                onClick={onClose}
+                className="flex-1 px-4 py-3 rounded-xl border border-border/50 bg-background/50 text-sm font-medium text-foreground hover:bg-foreground/5 transition-all duration-200"
+            >
+              取消
+            </button>
+            <button
+                onClick={handleConfirm}
+                className="flex-1 px-4 py-3 rounded-xl bg-foreground text-background text-sm font-semibold hover:opacity-90 transition-all duration-200 shadow-sm"
+            >
+              我知道了
+            </button>
           </div>
-        </div>
-
-        {/* 按钮 */}
-        <div className="flex gap-3 mt-6">
-          <button
-            onClick={onClose}
-            className="flex-1 px-4 py-3 rounded-xl border border-border/50 bg-background/50 text-sm font-medium text-foreground hover:bg-foreground/5 transition-all duration-200"
-          >
-            取消
-          </button>
-          <button
-            onClick={handleConfirm}
-            className="flex-1 px-4 py-3 rounded-xl bg-foreground text-background text-sm font-semibold hover:opacity-90 transition-all duration-200 shadow-sm"
-          >
-            前往设置
-          </button>
         </div>
       </div>
-    </div>
   );
 }

--- a/src/components/dialogs/AntivirusWarningDialog.tsx
+++ b/src/components/dialogs/AntivirusWarningDialog.tsx
@@ -6,21 +6,23 @@ interface AntivirusWarningDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onConfirm?: () => void;
+  mode?: "download" | "startup";
 }
 
 export function AntivirusWarningDialog({
-                                         isOpen,
-                                         onClose,
-                                         onConfirm,
-                                       }: AntivirusWarningDialogProps) {
+  isOpen,
+  onClose,
+  onConfirm,
+  mode = "download",
+}: AntivirusWarningDialogProps) {
   const [frpcDir, setFrpcDir] = useState<string>("");
   const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
       invoke<string>("get_frpc_directory")
-          .then(setFrpcDir)
-          .catch((err) => console.error("获取frpc目录失败:", err));
+        .then(setFrpcDir)
+        .catch((err) => console.error("获取frpc目录失败:", err));
     }
   }, [isOpen]);
 
@@ -41,91 +43,99 @@ export function AntivirusWarningDialog({
     }
   };
 
+  const isStartupMode = mode === "startup";
+
   return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm animate-in fade-in duration-200"
+      onClick={onClose}
+    >
       <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm animate-in fade-in duration-200"
-          onClick={onClose}
+        className="w-full max-w-md rounded-2xl bg-card/95 backdrop-blur-md border border-border/50 p-8 shadow-2xl animate-in zoom-in-95 slide-in-from-bottom-4 duration-300"
+        onClick={(e) => e.stopPropagation()}
       >
-        <div
-            className="w-full max-w-md rounded-2xl bg-card/95 backdrop-blur-md border border-border/50 p-8 shadow-2xl animate-in zoom-in-95 slide-in-from-bottom-4 duration-300"
-            onClick={(e) => e.stopPropagation()}
-        >
-          <div className="flex items-center justify-between mb-6">
-            <div className="flex items-center gap-3">
-              <div className="h-10 w-10 rounded-xl bg-gradient-to-br from-foreground to-foreground/80 flex items-center justify-center shadow-sm">
-                <AlertTriangle className="w-5 h-5 text-background" />
-              </div>
-              <div>
-                <h2 className="text-lg font-bold text-foreground">启动被阻止</h2>
-                <p className="text-xs text-muted-foreground">
-                  杀毒软件可能已删除 frpc 文件
-                </p>
-              </div>
+        <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center gap-3">
+            <div className="h-10 w-10 rounded-xl bg-gradient-to-br from-foreground to-foreground/80 flex items-center justify-center shadow-sm">
+              <AlertTriangle className="w-5 h-5 text-background" />
             </div>
-            <button
-                type="button"
-                className="h-8 w-8 rounded-lg text-muted-foreground hover:text-foreground hover:bg-foreground/10 transition-all duration-200 flex items-center justify-center"
-                onClick={onClose}
-            >
-              <X className="w-4 h-4" />
-            </button>
-          </div>
-
-          <div className="space-y-4">
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              frpc 客户端可能已被杀毒软件（如 Windows Defender）误判为可疑程序并被删除。
-              请将其安装目录添加到白名单，然后重新尝试启动隧道。
-            </p>
-
-            <div className="space-y-2">
-              <p className="text-sm font-medium text-foreground">
-                frpc 安装目录：
+            <div>
+              <h2 className="text-lg font-bold text-foreground">
+                {isStartupMode ? "启动被阻止" : "下载被拦截"}
+              </h2>
+              <p className="text-xs text-muted-foreground">
+                {isStartupMode
+                  ? "杀毒软件可能已删除 frpc 文件"
+                  : "杀毒软件阻止了下载"}
               </p>
-              <div className="flex items-center gap-2">
-                <div className="flex-1 px-3 py-2 rounded-lg border border-border/50 bg-background/50 text-xs font-mono text-foreground break-all">
-                  {frpcDir || "加载中..."}
-                </div>
-                <button
-                    onClick={handleCopy}
-                    disabled={!frpcDir}
-                    className="flex-shrink-0 h-8 w-8 rounded-lg border border-border/50 bg-background/50 flex items-center justify-center hover:bg-foreground/5 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
-                    title="复制路径"
-                >
-                  {copied ? (
-                      <Check className="w-4 h-4 text-green-500" />
-                  ) : (
-                      <Copy className="w-3.5 h-3.5 text-muted-foreground" />
-                  )}
-                </button>
-              </div>
             </div>
+          </div>
+          <button
+            type="button"
+            className="h-8 w-8 rounded-lg text-muted-foreground hover:text-foreground hover:bg-foreground/10 transition-all duration-200 flex items-center justify-center"
+            onClick={onClose}
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
 
-            <div className="space-y-2">
-              <p className="text-sm font-medium text-foreground">解决方法：</p>
-              <ol className="space-y-2 text-sm text-muted-foreground pl-5 list-decimal">
-                <li>打开杀毒软件设置</li>
-                <li>将上述目录添加到白名单（排除项）</li>
-                <li>进入软件设置重新下载frpc</li>
-                <li>重新尝试启动隧道</li>
-              </ol>
+        <div className="space-y-4">
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            {isStartupMode
+              ? "frpc 客户端可能已被杀毒软件（如 Windows Defender）误判为可疑程序并被删除。请将其安装目录添加到白名单，然后重新尝试启动隧道。"
+              : "frpc 客户端可能被杀毒软件（如 Windows Defender）误判为可疑程序。"}
+          </p>
+
+          <div className="space-y-2">
+            <p className="text-sm font-medium text-foreground">
+              frpc 安装目录：
+            </p>
+            <div className="flex items-center gap-2">
+              <div className="flex-1 px-3 py-2 rounded-lg border border-border/50 bg-background/50 text-xs font-mono text-foreground break-all">
+                {frpcDir || "加载中..."}
+              </div>
+              <button
+                onClick={handleCopy}
+                disabled={!frpcDir}
+                className="flex-shrink-0 h-8 w-8 rounded-lg border border-border/50 bg-background/50 flex items-center justify-center hover:bg-foreground/5 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+                title="复制路径"
+              >
+                {copied ? (
+                  <Check className="w-4 h-4 text-green-500" />
+                ) : (
+                  <Copy className="w-3.5 h-3.5 text-muted-foreground" />
+                )}
+              </button>
             </div>
           </div>
 
-          <div className="flex gap-3 mt-6">
-            <button
-                onClick={onClose}
-                className="flex-1 px-4 py-3 rounded-xl border border-border/50 bg-background/50 text-sm font-medium text-foreground hover:bg-foreground/5 transition-all duration-200"
-            >
-              取消
-            </button>
-            <button
-                onClick={handleConfirm}
-                className="flex-1 px-4 py-3 rounded-xl bg-foreground text-background text-sm font-semibold hover:opacity-90 transition-all duration-200 shadow-sm"
-            >
-              我知道了
-            </button>
+          <div className="space-y-2">
+            <p className="text-sm font-medium text-foreground">解决方法：</p>
+            <ol className="space-y-2 text-sm text-muted-foreground pl-5 list-decimal">
+              <li>打开杀毒软件设置</li>
+              <li>将上述目录添加到白名单（排除项）</li>
+              <li>
+                {isStartupMode ? "重新尝试启动隧道" : "重新下载 frpc 客户端"}
+              </li>
+            </ol>
           </div>
         </div>
+
+        <div className="flex gap-3 mt-6">
+          <button
+            onClick={onClose}
+            className="flex-1 px-4 py-3 rounded-xl border border-border/50 bg-background/50 text-sm font-medium text-foreground hover:bg-foreground/5 transition-all duration-200"
+          >
+            取消
+          </button>
+          <button
+            onClick={handleConfirm}
+            className="flex-1 px-4 py-3 rounded-xl bg-foreground text-background text-sm font-semibold hover:opacity-90 transition-all duration-200 shadow-sm"
+          >
+            {isStartupMode ? "我知道了" : "前往设置"}
+          </button>
+        </div>
       </div>
+    </div>
   );
 }

--- a/src/components/pages/TunnelList/hooks/useTunnelToggle.ts
+++ b/src/components/pages/TunnelList/hooks/useTunnelToggle.ts
@@ -7,6 +7,19 @@ import { customTunnelService } from "@/services/customTunnelService";
 import { logStore } from "@/services/logStore";
 import type { TunnelProgress, UnifiedTunnel } from "../types";
 
+// 判断是否为文件缺失错误
+function isFileMissingError(error: unknown): boolean {
+  const errorMsg = error instanceof Error ? error.message : String(error);
+  return (
+      errorMsg.includes("ENOENT") ||
+      errorMsg.includes("找不到") ||
+      errorMsg.includes("No such file") ||
+      errorMsg.includes("frpc") ||
+      errorMsg.includes("无法启动") ||
+      errorMsg.includes("未找到") ||
+      errorMsg.includes("系统找不到指定的文件")
+  );
+}
 interface UseTunnelToggleProps {
   setTunnelProgress: Dispatch<SetStateAction<Map<string, TunnelProgress>>>;
   setRunningTunnels: Dispatch<SetStateAction<Set<string>>>;
@@ -27,6 +40,8 @@ export function useTunnelToggle({
   const [togglingTunnels, setTogglingTunnels] = useState<Set<string>>(
     new Set(),
   );
+  // 控制弹窗显示状态
+  const [showWarningDialog, setShowWarningDialog] = useState(false);
 
   const handleToggle = async (tunnel: UnifiedTunnel, enabled: boolean) => {
     const tunnelKey =
@@ -131,21 +146,38 @@ export function useTunnelToggle({
         }
       }
     } catch (err) {
-      const message =
-        err instanceof Error ? err.message : `${enabled ? "启动" : "停止"}失败`;
-      toast.error(message);
-
-      if (enabled) {
-        const errorProgress = {
-          progress: 100,
-          isError: true,
-          isSuccess: false,
-        };
+      // 判断错误类型
+      if (enabled && isFileMissingError(err)) {
+        // 文件缺失：弹出提示窗，不 toast 错误
+        setShowWarningDialog(true);
+        // 仍然设置进度为错误
         setTunnelProgress((prev) => {
           const next = new Map(prev);
-          next.set(tunnelKey, errorProgress);
+          next.set(tunnelKey, {
+            progress: 100,
+            isError: true,
+            isSuccess: false,
+          });
           return next;
         });
+      } else {
+        // 其他错误：普通 toast
+        const message =
+            err instanceof Error ? err.message : `${enabled ? "启动" : "停止"}失败`;
+        toast.error(message);
+
+        if (enabled) {
+          const errorProgress = {
+            progress: 100,
+            isError: true,
+            isSuccess: false,
+          };
+          setTunnelProgress((prev) => {
+            const next = new Map(prev);
+            next.set(tunnelKey, errorProgress);
+            return next;
+          });
+        }
       }
     } finally {
       setTogglingTunnels((prev) => {
@@ -156,8 +188,14 @@ export function useTunnelToggle({
     }
   };
 
-  return {
-    togglingTunnels,
-    handleToggle,
-  };
-}
+    const closeWarningDialog = () => {
+      setShowWarningDialog(false);
+    };
+
+    return {
+      togglingTunnels,
+      handleToggle,
+      showWarningDialog,
+      closeWarningDialog,
+    };
+  }

--- a/src/components/pages/TunnelList/index.tsx
+++ b/src/components/pages/TunnelList/index.tsx
@@ -19,6 +19,7 @@ import { CreateTunnelDialog } from "./components/CreateTunnelDialog";
 import { EditTunnelDialog } from "./components/EditTunnelDialog";
 import { EditCustomTunnelDialog } from "./components/EditCustomTunnelDialog";
 import { CustomTunnelDialog } from "./components/CustomTunnelDialog";
+import { AntivirusWarningDialog} from "@/components/dialogs/AntivirusWarningDialog.tsx";
 import {
   fetchNodes,
   type Tunnel,
@@ -39,12 +40,12 @@ export function TunnelList({ user }: TunnelListProps) {
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [, setLoadingEditDialog] = useState(false);
   const [preloadedEditNodes, setPreloadedEditNodes] = useState<Node[] | null>(
-    null,
+      null,
   );
   const [editingTunnel, setEditingTunnel] = useState<Tunnel | null>(null);
   const [editCustomDialogOpen, setEditCustomDialogOpen] = useState(false);
   const [editingCustomTunnel, setEditingCustomTunnel] =
-    useState<CustomTunnel | null>(null);
+      useState<CustomTunnel | null>(null);
   const [createCustomDialogOpen, setCreateCustomDialogOpen] = useState(false);
 
   const {
@@ -57,14 +58,19 @@ export function TunnelList({ user }: TunnelListProps) {
   } = useTunnelList();
 
   const apiTunnels = useMemo(
-    () => tunnels.filter((t) => t.type === "api").map((t) => t.data),
-    [tunnels],
+      () => tunnels.filter((t) => t.type === "api").map((t) => t.data),
+      [tunnels],
   );
 
   const { tunnelProgress, setTunnelProgress, timeoutRefs, successTimeoutRefs } =
-    useTunnelProgress(apiTunnels, runningTunnels, setRunningTunnels);
+      useTunnelProgress(apiTunnels, runningTunnels, setRunningTunnels);
 
-  const { togglingTunnels, handleToggle } = useTunnelToggle({
+  const {
+    togglingTunnels,
+    handleToggle,
+    showWarningDialog,
+    closeWarningDialog,
+  } = useTunnelToggle({
     setTunnelProgress,
     setRunningTunnels,
     timeoutRefs,
@@ -84,7 +90,7 @@ export function TunnelList({ user }: TunnelListProps) {
       setCreateDialogOpen(true);
     } catch (error) {
       const message =
-        error instanceof Error ? error.message : "获取节点列表失败";
+          error instanceof Error ? error.message : "获取节点列表失败";
       toast.error(message);
     } finally {
       setLoadingCreateDialog(false);
@@ -100,7 +106,7 @@ export function TunnelList({ user }: TunnelListProps) {
       setEditDialogOpen(true);
     } catch (error) {
       const message =
-        error instanceof Error ? error.message : "获取节点列表失败";
+          error instanceof Error ? error.message : "获取节点列表失败";
       toast.error(message);
     } finally {
       setLoadingEditDialog(false);
@@ -108,188 +114,198 @@ export function TunnelList({ user }: TunnelListProps) {
   }, []);
 
   const handleEdit = useCallback(
-    (tunnel: UnifiedTunnel) => {
-      if (tunnel.type === "api") {
-        handleOpenEditDialog(tunnel.data);
-      } else if (tunnel.type === "custom") {
-        setEditingCustomTunnel(tunnel.data);
-        setEditCustomDialogOpen(true);
-      }
-    },
-    [handleOpenEditDialog],
+      (tunnel: UnifiedTunnel) => {
+        if (tunnel.type === "api") {
+          handleOpenEditDialog(tunnel.data);
+        } else if (tunnel.type === "custom") {
+          setEditingCustomTunnel(tunnel.data);
+          setEditCustomDialogOpen(true);
+        }
+      },
+      [handleOpenEditDialog],
   );
 
   return (
-    <div className="flex flex-col h-full gap-4">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <h1 className="text-xl font-medium text-foreground">隧道</h1>
-          {!loading && !error && (
-            <span className="text-xs text-muted-foreground">
+      <div className="flex flex-col h-full gap-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <h1 className="text-xl font-medium text-foreground">隧道</h1>
+            {!loading && !error && (
+                <span className="text-xs text-muted-foreground">
               {tunnels.length} 个
             </span>
-          )}
-        </div>
-        <Button
-          size="sm"
-          onClick={handleOpenCreateDialog}
-          disabled={loadingCreateDialog}
-          className="h-8 px-3 text-xs"
-        >
-          {loadingCreateDialog ? (
-            <>
-              <svg
-                className="animate-spin h-3.5 w-3.5 mr-1.5"
-                viewBox="0 0 24 24"
-              >
-                <circle
-                  className="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="4"
-                  fill="none"
-                />
-                <path
-                  className="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                />
-              </svg>
-              加载中...
-            </>
-          ) : (
-            "新建隧道"
-          )}
-        </Button>
-      </div>
-
-      {loading ? (
-        <div className="flex-1 flex items-center justify-center text-sm text-muted-foreground">
-          加载中...
-        </div>
-      ) : error ? (
-        <div className="flex-1 flex items-center justify-center text-sm text-muted-foreground">
-          {error}
-        </div>
-      ) : tunnels.length === 0 ? (
-        <Empty className="flex-1">
-          <EmptyHeader>
-            <EmptyMedia variant="icon">
-              <Network className="size-6" />
-            </EmptyMedia>
-            <EmptyTitle>暂无隧道</EmptyTitle>
-            <EmptyDescription>
-              您还没有创建任何隧道，点击下方按钮开始创建您的第一个隧道。
-            </EmptyDescription>
-          </EmptyHeader>
-          <EmptyContent>
-            <Button
-              variant="outline"
+            )}
+          </div>
+          <Button
               size="sm"
               onClick={handleOpenCreateDialog}
               disabled={loadingCreateDialog}
-            >
-              {loadingCreateDialog ? (
+              className="h-8 px-3 text-xs"
+          >
+            {loadingCreateDialog ? (
                 <>
                   <svg
-                    className="animate-spin h-3.5 w-3.5 mr-1.5"
-                    viewBox="0 0 24 24"
+                      className="animate-spin h-3.5 w-3.5 mr-1.5"
+                      viewBox="0 0 24 24"
                   >
                     <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                      fill="none"
+                        className="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                        fill="none"
                     />
                     <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                        className="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
                     />
                   </svg>
                   加载中...
                 </>
-              ) : (
+            ) : (
                 "新建隧道"
-              )}
-            </Button>
-          </EmptyContent>
-        </Empty>
-      ) : (
-        <ScrollArea className="flex-1 min-h-0 pr-1">
-          <div className="grid grid-cols-2 lg:grid-cols-3 gap-3">
-            {tunnels.map((tunnel) => {
-              const tunnelKey =
-                tunnel.type === "api"
-                  ? `api_${tunnel.data.id}`
-                  : `custom_${tunnel.data.id}`;
-              const isRunning = runningTunnels.has(tunnelKey);
-              const isToggling = togglingTunnels.has(tunnelKey);
-              const progress =
-                tunnel.type === "api"
-                  ? tunnelProgress.get(tunnelKey)
-                  : undefined;
-              return (
-                <TunnelCard
-                  key={tunnelKey}
-                  tunnel={tunnel}
-                  isRunning={isRunning}
-                  isToggling={isToggling}
-                  progress={progress}
-                  onToggle={handleToggle}
-                  onRefresh={refreshTunnels}
-                  onEdit={handleEdit}
-                />
-              );
-            })}
-          </div>
-        </ScrollArea>
-      )}
+            )}
+          </Button>
+        </div>
 
-      <CreateTunnelDialog
-        open={createDialogOpen}
-        onOpenChange={(open) => {
-          setCreateDialogOpen(open);
-          if (!open) {
-            setPreloadedNodes(null);
-          }
-        }}
-        onSuccess={refreshTunnels}
-        preloadedNodes={preloadedNodes}
-        user={user}
-      />
+        {loading ? (
+            <div className="flex-1 flex items-center justify-center text-sm text-muted-foreground">
+              加载中...
+            </div>
+        ) : error ? (
+            <div className="flex-1 flex items-center justify-center text-sm text-muted-foreground">
+              {error}
+            </div>
+        ) : tunnels.length === 0 ? (
+            <Empty className="flex-1">
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <Network className="size-6" />
+                </EmptyMedia>
+                <EmptyTitle>暂无隧道</EmptyTitle>
+                <EmptyDescription>
+                  您还没有创建任何隧道，点击下方按钮开始创建您的第一个隧道。
+                </EmptyDescription>
+              </EmptyHeader>
+              <EmptyContent>
+                <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleOpenCreateDialog}
+                    disabled={loadingCreateDialog}
+                >
+                  {loadingCreateDialog ? (
+                      <>
+                        <svg
+                            className="animate-spin h-3.5 w-3.5 mr-1.5"
+                            viewBox="0 0 24 24"
+                        >
+                          <circle
+                              className="opacity-25"
+                              cx="12"
+                              cy="12"
+                              r="10"
+                              stroke="currentColor"
+                              strokeWidth="4"
+                              fill="none"
+                          />
+                          <path
+                              className="opacity-75"
+                              fill="currentColor"
+                              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                          />
+                        </svg>
+                        加载中...
+                      </>
+                  ) : (
+                      "新建隧道"
+                  )}
+                </Button>
+              </EmptyContent>
+            </Empty>
+        ) : (
+            <ScrollArea className="flex-1 min-h-0 pr-1">
+              <div className="grid grid-cols-2 lg:grid-cols-3 gap-3">
+                {tunnels.map((tunnel) => {
+                  const tunnelKey =
+                      tunnel.type === "api"
+                          ? `api_${tunnel.data.id}`
+                          : `custom_${tunnel.data.id}`;
+                  const isRunning = runningTunnels.has(tunnelKey);
+                  const isToggling = togglingTunnels.has(tunnelKey);
+                  const progress =
+                      tunnel.type === "api"
+                          ? tunnelProgress.get(tunnelKey)
+                          : undefined;
+                  return (
+                      <TunnelCard
+                          key={tunnelKey}
+                          tunnel={tunnel}
+                          isRunning={isRunning}
+                          isToggling={isToggling}
+                          progress={progress}
+                          onToggle={handleToggle}
+                          onRefresh={refreshTunnels}
+                          onEdit={handleEdit}
+                      />
+                  );
+                })}
+              </div>
+            </ScrollArea>
+        )}
 
-      <EditTunnelDialog
-        open={editDialogOpen}
-        onOpenChange={(open) => {
-          setEditDialogOpen(open);
-          if (!open) {
-            setPreloadedEditNodes(null);
-          }
-        }}
-        onSuccess={refreshTunnels}
-        tunnel={editingTunnel}
-        preloadedNodes={preloadedEditNodes}
-        user={user}
-      />
+        <CreateTunnelDialog
+            open={createDialogOpen}
+            onOpenChange={(open) => {
+              setCreateDialogOpen(open);
+              if (!open) {
+                setPreloadedNodes(null);
+              }
+            }}
+            onSuccess={refreshTunnels}
+            preloadedNodes={preloadedNodes}
+            user={user}
+        />
 
-      <EditCustomTunnelDialog
-        open={editCustomDialogOpen}
-        onOpenChange={setEditCustomDialogOpen}
-        onSuccess={refreshTunnels}
-        tunnel={editingCustomTunnel}
-      />
+        <EditTunnelDialog
+            open={editDialogOpen}
+            onOpenChange={(open) => {
+              setEditDialogOpen(open);
+              if (!open) {
+                setPreloadedEditNodes(null);
+              }
+            }}
+            onSuccess={refreshTunnels}
+            tunnel={editingTunnel}
+            preloadedNodes={preloadedEditNodes}
+            user={user}
+        />
 
-      <CustomTunnelDialog
-        open={createCustomDialogOpen}
-        onOpenChange={setCreateCustomDialogOpen}
-        onSuccess={refreshTunnels}
-      />
-    </div>
+        <EditCustomTunnelDialog
+            open={editCustomDialogOpen}
+            onOpenChange={setEditCustomDialogOpen}
+            onSuccess={refreshTunnels}
+            tunnel={editingCustomTunnel}
+        />
+
+        <CustomTunnelDialog
+            open={createCustomDialogOpen}
+            onOpenChange={setCreateCustomDialogOpen}
+            onSuccess={refreshTunnels}
+        />
+
+        {/* 反病毒警告弹窗 */}
+        <AntivirusWarningDialog
+            isOpen={showWarningDialog}
+            onClose={closeWarningDialog}
+            onConfirm={() => {
+              closeWarningDialog();
+              toast.info("请将显示的目录添加到白名单后重新尝试启动");
+            }}
+        />
+      </div>
   );
 }

--- a/src/components/pages/TunnelList/index.tsx
+++ b/src/components/pages/TunnelList/index.tsx
@@ -19,7 +19,7 @@ import { CreateTunnelDialog } from "./components/CreateTunnelDialog";
 import { EditTunnelDialog } from "./components/EditTunnelDialog";
 import { EditCustomTunnelDialog } from "./components/EditCustomTunnelDialog";
 import { CustomTunnelDialog } from "./components/CustomTunnelDialog";
-import { AntivirusWarningDialog} from "@/components/dialogs/AntivirusWarningDialog.tsx";
+import { AntivirusWarningDialog} from "@/components/dialogs/AntivirusWarningDialog";
 import {
   fetchNodes,
   type Tunnel,
@@ -297,15 +297,15 @@ export function TunnelList({ user }: TunnelListProps) {
             onSuccess={refreshTunnels}
         />
 
-        {/* 反病毒警告弹窗 */}
-        <AntivirusWarningDialog
-            isOpen={showWarningDialog}
-            onClose={closeWarningDialog}
-            onConfirm={() => {
-              closeWarningDialog();
-              toast.info("请将显示的目录添加到白名单后重新尝试启动");
-            }}
-        />
+          {/* 反病毒警告弹窗（启动场景） */}
+          <AntivirusWarningDialog
+              isOpen={showWarningDialog}
+              onClose={closeWarningDialog}
+              onConfirm={() => {
+                  closeWarningDialog();
+              }}
+              mode="startup"
+          />
       </div>
   );
 }

--- a/src/services/frpcManager.ts
+++ b/src/services/frpcManager.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn, type Event } from "@tauri-apps/api/event";
 import { getNodeUdpSupport, type Tunnel } from "./api";
+import { logStore} from "@/services/logStore.ts";
 
 export interface LogMessage {
   tunnel_id: number;
@@ -105,7 +106,42 @@ export class FrpcManager {
       kcp_optimization: kcpOptimization,
     };
 
-    return await invoke<string>("start_frpc", { config });
+    try {
+      return await invoke<string>("start_frpc", { config });
+    } catch (error: unknown) {
+      // 将 error 转换为字符串
+      const errorMsg = error instanceof Error ? error.message : String(error);
+
+      // 检测是否与文件缺失相关
+      const isFileMissing =
+          errorMsg.includes("ENOENT") ||
+          errorMsg.includes("找不到") ||
+          errorMsg.includes("No such file") ||
+          errorMsg.includes("frpc") ||
+          errorMsg.includes("无法启动") ||
+          errorMsg.includes("未找到");
+
+      if (isFileMissing) {
+        const timestamp = new Date()
+            .toLocaleString("zh-CN", {
+              year: "numeric",
+              month: "2-digit",
+              day: "2-digit",
+              hour: "2-digit",
+              minute: "2-digit",
+              second: "2-digit",
+              hour12: false,
+            })
+            .replace(/\//g, "/");
+
+        logStore.addLog({
+          tunnel_id: tunnel.id,
+          message: `[E] [ChmlFrpLauncher] 启动失败：frpc 可执行文件不存在，frpc 客户端可能被杀毒软件（如WindowsDefender）误判为可疑程序。`,
+          timestamp,
+        });
+      }
+      throw error;
+    }
   }
 
   async stopTunnel(tunnelId: number): Promise<string> {

--- a/src/services/frpcManager.ts
+++ b/src/services/frpcManager.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn, type Event } from "@tauri-apps/api/event";
 import { getNodeUdpSupport, type Tunnel } from "./api";
-import { logStore} from "@/services/logStore.ts";
+import { logStore} from "@/services/logStore";
 
 export interface LogMessage {
   tunnel_id: number;


### PR DESCRIPTION
当frpc可执行文件被安全软件（如Windows Defender）误删时，
用户启动隧道仅看到toast错误提示，缺乏明确的解决指引。

改动内容：
- 新增AntivirusWarningDialog弹窗组件，展示frpc安装目录
  和添加白名单的详细步骤
- 修改frpcManager.startTunnel，捕获文件缺失错误并写入日志
- 修改useTunnelToggle，错误类型判断后触发弹窗而非普通toast
- 在TunnelList中集成弹窗，消费showWarningDialog状态

用户现在可以：
1. 通过弹窗明确了解启动失败原因
2. 一键复制frpc目录路径
3. 按照清晰的步骤操作，自行添加白名单